### PR TITLE
add schema for JSON input

### DIFF
--- a/docs/schema/.gitignore
+++ b/docs/schema/.gitignore
@@ -1,0 +1,1 @@
+schema_doc.*

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -1,0 +1,13 @@
+# JSON schema for GFCC
+
+## Input schema
+
+`input_schema.json` is a JSON schema for the GFCC input API.
+
+You can generate a documentation from it as follows:
+
+```
+pip install json-schema-for-humans
+generate-schema-doc input_schema.json
+```
+Now, open `schema_doc.html` in your browser.

--- a/docs/schema/input_schema.json
+++ b/docs/schema/input_schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "geometry": {
+      "type": "object",
+      "properties": {
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "units": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "coordinates",
+        "units"
+      ]
+    },
+    "basis": {
+      "type": "object",
+      "properties": {
+        "basisset": {
+          "type": "string"
+        },
+        "gaussian_type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "basisset",
+        "gaussian_type"
+      ]
+    },
+    "common": {
+      "type": "object",
+      "properties": {
+        "maxiter": {
+          "type": "integer"
+        },
+        "debug": {
+          "type": "boolean"
+        },
+        "output_file_prefix": {
+          "type": "string"
+        }
+      }
+    },
+    "SCF": {
+      "type": "object",
+      "properties": {
+        "tol_int": {
+          "type": "number"
+        },
+        "tol_lindep": {
+          "type": "number"
+        },
+        "conve": {
+          "type": "number"
+        },
+        "convd": {
+          "type": "number"
+        },
+        "diis_hist": {
+          "type": "integer"
+        },
+        "tilesize": {
+          "type": "integer"
+        },
+        "charge": {
+          "type": "integer"
+        },
+        "scf_type": {
+          "type": "string"
+        },
+        "multiplicity": {
+          "type": "integer"
+        },
+        "lshift": {
+          "type": "integer"
+        },
+        "force_tilesize": {
+          "type": "boolean"
+        },
+        "alpha": {
+          "type": "number"
+        },
+        "nnodes": {
+          "type": "integer"
+        },
+        "writem": {
+          "type": "integer"
+        },
+        "restart": {
+          "type": "boolean"
+        },
+        "noscf": {
+          "type": "boolean"
+        },
+        "debug": {
+          "type": "boolean"
+        }
+      }
+    },
+    "CD": {
+      "type": "object",
+      "properties": {
+        "diagtol": {
+          "type": "number"
+        },
+        "max_cvecs": {
+          "type": "integer"
+        }
+      }
+    },
+    "CC": {
+      "type": "object",
+      "properties": {
+        "threshold": {
+          "type": "number"
+        },
+        "writet": {
+          "type": "boolean"
+        },
+        "debug": {
+          "type": "boolean"
+        },
+        "GFCCSD": {
+          "type": "object",
+          "properties": {
+            "gf_ip": {
+              "type": "boolean"
+            },
+            "gf_p_oi_range": {
+              "type": "integer"
+            },
+            "gf_eta": {
+              "type": "number"
+            },
+            "gf_threshold": {
+              "type": "number"
+            },
+            "gf_maxiter": {
+              "type": "integer"
+            },
+            "gf_ngmres": {
+              "type": "integer"
+            },
+            "gf_damping_factor": {
+              "type": "number"
+            },
+            "gf_omega_min_ip": {
+              "type": "number"
+            },
+            "gf_omega_max_ip": {
+              "type": "number"
+            },
+            "gf_omega_min_ip_e": {
+              "type": "number"
+            },
+            "gf_omega_max_ip_e": {
+              "type": "number"
+            },
+            "gf_omega_delta": {
+              "type": "number"
+            },
+            "gf_omega_delta_e": {
+              "type": "number"
+            },
+            "gf_cs": {
+              "type": "boolean"
+            },
+            "gf_orbitals": {
+              "type": "array"
+            },
+            "gf_extrapolate_level": {
+              "type": "integer"
+            },
+            "gf_analyze_level": {
+              "type": "integer"
+            },
+            "gf_analyze_num_omega": {
+              "type": "integer"
+            },
+            "gf_analyze_omega": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "gf_itriples": {
+              "type": "boolean"
+            }
+          }
+        },
+        "lshift": {
+          "type": "integer"
+        },
+        "ndiis": {
+          "type": "integer"
+        },
+        "ccsd_maxiter": {
+          "type": "integer"
+        },
+        "printtol": {
+          "type": "number"
+        },
+        "readt": {
+          "type": "boolean"
+        },
+        "writev": {
+          "type": "boolean"
+        },
+        "writet_iter": {
+          "type": "integer"
+        },
+        "profile_ccsd": {
+          "type": "boolean"
+        },
+        "tilesize": {
+          "type": "integer"
+        },
+        "force_tilesize": {
+          "type": "boolean"
+        },
+        "CCSD(T)": {
+          "type": "object",
+          "properties": {
+            "ngpu": {
+              "type": "integer"
+            },
+            "ccsdt_tilesize": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "basis",
+    "common",
+    "geometry"
+  ]
+}


### PR DESCRIPTION
Generated with `genson` python package from sample input files in
`tests/` folder.

Can be used to generate documentation via `json-schema-for-humans


![schema](https://user-images.githubusercontent.com/1053245/167916573-decb21fd-4c7a-4891-b313-a5a0dc7719e6.gif)
`